### PR TITLE
UI overhaul with new themes

### DIFF
--- a/Scripts/index_script.js
+++ b/Scripts/index_script.js
@@ -26,18 +26,6 @@ document.addEventListener("DOMContentLoaded", () => {
     };
   }
 
-  const observer = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          const img = entry.target;
-          img.src = img.dataset.src;
-          observer.unobserve(img);
-        }
-      });
-    },
-    { rootMargin: "100px" }
-  );
 
   function highlight(text, query) {
     if (!query) return text;
@@ -71,6 +59,8 @@ document.addEventListener("DOMContentLoaded", () => {
     { name: "blue", path: "Styles/Themes/theme-blue.css" },
     { name: "green", path: "Styles/Themes/theme-green.css" },
     { name: "purple", path: "Styles/Themes/theme-purple.css" },
+    { name: "teal", path: "Styles/Themes/theme-teal.css" },
+    { name: "orange", path: "Styles/Themes/theme-orange.css" },
   ];
   let currentThemeIndex = 0;
 
@@ -168,38 +158,27 @@ document.addEventListener("DOMContentLoaded", () => {
     // Basic structure with placeholders for image/icon
     cardElement.innerHTML = `
       <div class="card-image">
-        <button class="fav-btn" title="افزودن به علاقه‌مندی‌ها">
-          <i class="${favorites.has(cardInfo.url) ? "fas" : "far"} fa-star"></i>
-        </button>
+        <i class="${cardInfo.icon || 'fas fa-globe'}"></i>
       </div>
       <div class="card-content">
         <div>
           <h3>${highlight(cardInfo.title || "بدون عنوان", searchQuery)}</h3>
-          <p class="subtitle">${highlight(
-            cardInfo.subtitle || "",
-            searchQuery
-          )}</p>
           <p class="description">${highlight(
-            cardInfo.description || "توضیحی وجود ندارد.",
+            cardInfo.description || "",
             searchQuery
           )}</p>
         </div>
         <div class="card-actions">
-          <a href="${
-            cardInfo.visitLink || cardInfo.url || "#"
-          }" class="btn outline" target="_blank" rel="noopener noreferrer">
-            <i class="fas fa-globe"></i> مشاهده
-          </a>
-          <a href="${
-            cardInfo.detailsLink || cardInfo.url || "#"
-          }" class="btn" target="_blank" rel="noopener noreferrer">
-            <i class="fas fa-info-circle"></i> جزئیات
+          <button class="fav-btn ${favorites.has(cardInfo.url) ? 'active' : ''}">
+            <i class="${favorites.has(cardInfo.url) ? 'fas' : 'far'} fa-star"></i> Favorite
+          </button>
+          <a href="${cardInfo.url || '#'}" class="btn" target="_blank" rel="noopener noreferrer">
+            <i class="fas fa-external-link-alt"></i> Open
           </a>
         </div>
       </div>
     `;
 
-    const imageDiv = cardElement.querySelector(".card-image");
     const favButton = cardElement.querySelector(".fav-btn");
 
     favButton.addEventListener("click", () => {
@@ -218,40 +197,7 @@ document.addEventListener("DOMContentLoaded", () => {
       );
     });
 
-    const siteUrl = cardInfo.visitLink || cardInfo.url;
-    if (
-      siteUrl &&
-      (siteUrl.startsWith("http://") || siteUrl.startsWith("https://"))
-    ) {
-      const img = document.createElement("img");
-      img.dataset.src = `https://s.wordpress.com/mshots/v1/${encodeURIComponent(
-        siteUrl
-      )}`;
-      img.alt = cardInfo.title || "thumbnail";
-      img.style.width = "100%";
-      img.style.height = "100%";
-      img.style.objectFit = "cover";
 
-      img.onerror = () => {
-        // fallback to icon
-        imageDiv.innerHTML = `<i class="${
-          cardInfo.icon || "fas fa-link"
-        } fa-3x"></i>`;
-      };
-
-      imageDiv.innerHTML = "";
-      imageDiv.appendChild(img);
-      observer.observe(img);
-    } else if (cardInfo.icon) {
-      imageDiv.innerHTML = `<i class="${cardInfo.icon} fa-3x"></i>`;
-    } else {
-      const img = document.createElement("img");
-      img.dataset.src = "Images/Icon.png";
-      img.alt = cardInfo.title || "thumbnail";
-      imageDiv.innerHTML = "";
-      imageDiv.appendChild(img);
-      observer.observe(img);
-    }
 
     return cardElement;
   }
@@ -343,11 +289,12 @@ document.addEventListener("DOMContentLoaded", () => {
       const formData = new FormData(addCardForm);
       const title = formData.get("title").trim();
       const url = formData.get("url").trim();
+      const description = formData.get("description").trim();
       if (!title || !isValidUrl(url)) {
         alert("Please enter a valid title and URL");
         return;
       }
-      const newCard = { title, url };
+      const newCard = { title, url, description };
       try {
         const stored = JSON.parse(localStorage.getItem("cardsDataALDMC")) || [];
         stored.push(newCard);
@@ -363,13 +310,30 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   // =================== INITIAL DATA FETCH & RENDER ===================
+  const defaultCards = [
+    {
+      title: "OpenAI",
+      url: "https://openai.com",
+      description: "Artificial intelligence research lab"
+    },
+    {
+      title: "Mozilla",
+      url: "https://www.mozilla.org",
+      description: "Creators of the Firefox browser"
+    },
+    {
+      title: "Wikipedia",
+      url: "https://wikipedia.org",
+      description: "Free online encyclopedia"
+    }
+  ];
   async function initializeApp() {
     try {
       const stored = localStorage.getItem("cardsDataALDMC");
-      allCardsData = stored ? JSON.parse(stored) : [];
+      allCardsData = stored ? JSON.parse(stored) : defaultCards;
     } catch (error) {
       console.error("خطا در خواندن داده‌های ذخیره شده:", error);
-      allCardsData = [];
+      allCardsData = defaultCards;
     }
 
     const categories = getUniqueCategories(allCardsData);

--- a/Styles/Themes/theme-blue.css
+++ b/Styles/Themes/theme-blue.css
@@ -15,4 +15,6 @@
   --category-border: #c2c8f0;
   --card-glow: rgba(63, 81, 181, 0.07);
   --card-glow-hover: rgba(63, 81, 181, 0.33);
+  --gradient-start: #8f94fb;
+  --gradient-end: #4e54c8;
 }

--- a/Styles/Themes/theme-dark.css
+++ b/Styles/Themes/theme-dark.css
@@ -15,4 +15,6 @@
   --category-border: #23252e; /* ← خط border خیلی subtle و خفن */
   --card-glow: rgba(255, 111, 60, 0.11);
   --card-glow-hover: rgba(255, 170, 120, 0.42);
+  --gradient-start: #414345;
+  --gradient-end: #232526;
 }

--- a/Styles/Themes/theme-default.css
+++ b/Styles/Themes/theme-default.css
@@ -15,4 +15,6 @@
   --category-border: #d6dae3; /* ← خط border خیلی نرم، نزدیک به دسته‌بندی */
   --card-glow: rgba(255, 111, 60, 0.07); /* subtle shadow حالت عادی */
   --card-glow-hover: rgba(255, 111, 60, 0.33); /* glow روشن و قوی روی هاور */
+  --gradient-start: #ff9966;
+  --gradient-end: #ff5e62;
 }

--- a/Styles/Themes/theme-green.css
+++ b/Styles/Themes/theme-green.css
@@ -15,4 +15,6 @@
   --category-border: #cde8cf;
   --card-glow: rgba(76, 175, 80, 0.07);
   --card-glow-hover: rgba(76, 175, 80, 0.33);
+  --gradient-start: #a8ff78;
+  --gradient-end: #78ffd6;
 }

--- a/Styles/Themes/theme-orange.css
+++ b/Styles/Themes/theme-orange.css
@@ -1,0 +1,20 @@
+:root {
+  --primary: #ff5722;
+  --primary-dark: #e64a19;
+  --primary-rgb: 255, 87, 34;
+  --background: #fff4e0;
+  --header-bg: #bf360c;
+  --text: #222;
+  --text-light: #ffe0b2;
+  --card-bg: #fff;
+  --card-border: #ffccbc;
+  --card-image-bg: #ffe0b2;
+  --dropdown-bg: white;
+  --dropdown-text: #222;
+  --category-bg: #ffe5d1;
+  --category-border: #ffc7b0;
+  --card-glow: rgba(255,87,34,0.07);
+  --card-glow-hover: rgba(255,87,34,0.33);
+  --gradient-start: #ff9a9e;
+  --gradient-end: #f83600;
+}

--- a/Styles/Themes/theme-purple.css
+++ b/Styles/Themes/theme-purple.css
@@ -15,4 +15,6 @@
   --category-border: #d8b5ef;
   --card-glow: rgba(156, 39, 176, 0.07);
   --card-glow-hover: rgba(156, 39, 176, 0.33);
+  --gradient-start: #b721ff;
+  --gradient-end: #21d4fd;
 }

--- a/Styles/Themes/theme-teal.css
+++ b/Styles/Themes/theme-teal.css
@@ -1,0 +1,20 @@
+:root {
+  --primary: #009688;
+  --primary-dark: #00695c;
+  --primary-rgb: 0, 150, 136;
+  --background: #e0f2f1;
+  --header-bg: #004d40;
+  --text: #222;
+  --text-light: #e0f2f1;
+  --card-bg: #fff;
+  --card-border: #b2dfdb;
+  --card-image-bg: #b2dfdb;
+  --dropdown-bg: white;
+  --dropdown-text: #222;
+  --category-bg: #c8ebe9;
+  --category-border: #a5d5d3;
+  --card-glow: rgba(0,150,136,0.07);
+  --card-glow-hover: rgba(0,150,136,0.33);
+  --gradient-start: #20e2d7;
+  --gradient-end: #1fa2ff;
+}

--- a/Styles/index_style.css
+++ b/Styles/index_style.css
@@ -1,13 +1,25 @@
 /* ===== FONTS ===== */
 @font-face {
-  font-family: "Inter";
-  src: url("../Fonts/Inter-Regular-slnt=0.ttf") format("truetype");
+  font-family: "Quicksand";
+  src: url("../Fonts/Quicksand-Regular.ttf") format("truetype");
   font-weight: 400;
   font-style: normal;
 }
 @font-face {
-  font-family: "Inter";
-  src: url("../Fonts/Inter-Bold-slnt=0.ttf") format("truetype");
+  font-family: "Quicksand";
+  src: url("../Fonts/Quicksand-Medium.ttf") format("truetype");
+  font-weight: 500;
+  font-style: normal;
+}
+@font-face {
+  font-family: "Quicksand";
+  src: url("../Fonts/Quicksand-SemiBold.ttf") format("truetype");
+  font-weight: 600;
+  font-style: normal;
+}
+@font-face {
+  font-family: "Quicksand";
+  src: url("../Fonts/Quicksand-Bold.ttf") format("truetype");
   font-weight: 700;
   font-style: normal;
 }
@@ -17,7 +29,7 @@
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  font-family: "Inter", sans-serif;
+  font-family: "Quicksand", sans-serif;
 }
 
 html,
@@ -47,8 +59,8 @@ header {
   z-index: 1000;
   background: radial-gradient(
     circle at top left,
-    var(--primary-dark),
-    var(--header-bg)
+    var(--gradient-start),
+    var(--gradient-end)
   );
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
@@ -60,8 +72,8 @@ header {
   padding: 0 60px;
   background: radial-gradient(
     circle at top left,
-    var(--primary-dark),
-    var(--header-bg)
+    var(--gradient-start),
+    var(--gradient-end)
   );
   color: var(--text-light);
   height: 90px;
@@ -71,7 +83,7 @@ header.header-scrolled {
   height: 70px;
   padding-top: 0;
   padding-bottom: 0;
-  background: linear-gradient(135deg, var(--header-bg), var(--primary-dark));
+  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
@@ -140,25 +152,23 @@ header.header-scrolled #title {
 #toggle-theme {
   font-size: 0.8rem;
   padding: 9px 18px;
-  background-color: transparent;
-  color: var(--text-light);
-  border: 1.5px solid var(--text-light);
-  border-radius: 25px;
+  background-image: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+  color: #fff;
+  border: none;
+  border-radius: 30px;
   cursor: pointer;
-  transition: all 0.3s;
+  transition: transform 0.3s, box-shadow 0.3s;
   margin-left: 15px;
   font-weight: 600;
+  box-shadow: 0 2px 8px rgba(var(--primary-rgb, 255, 111, 60), 0.4);
 }
 #toggle-theme:hover {
-  background-color: var(--primary);
-  color: white;
-  border-color: var(--primary);
   transform: translateY(-2px) scale(1.03);
-  box-shadow: 0 5px 10px rgba(var(--primary-rgb, 255, 111, 60), 0.3);
+  box-shadow: 0 6px 12px rgba(var(--primary-rgb, 255, 111, 60), 0.5);
 }
 #toggle-theme:active {
   transform: translateY(0px) scale(1);
-  box-shadow: 0 2px 5px rgba(var(--primary-rgb, 255, 111, 60), 0.2);
+  box-shadow: 0 2px 4px rgba(var(--primary-rgb, 255, 111, 60), 0.3);
 }
 /* =================== LAYOUT =================== */
 .content-wrapper {
@@ -279,17 +289,17 @@ main {
   padding: 30px 0;
 }
 
-/* =================== CARD GRID =================== */
-.card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 40px;
+/* =================== CARD LIST =================== */
+.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
   padding: 20px 0;
   opacity: 1;
   transition: opacity 0.2s cubic-bezier(0.6, 0, 0.3, 1);
 }
 
-.card-grid.animating {
+.card-list.animating {
   opacity: 0;
   pointer-events: none;
 }
@@ -308,10 +318,10 @@ main {
   border: 1px solid var(--card-border, #ddd);
   box-shadow: 0 8px 24px -4px var(--card-glow, rgba(0, 0, 0, 0.1));
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   overflow: hidden;
   width: 100%;
-  min-height: 400px;
+  min-height: 180px;
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
     box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.4s ease,
     border-color 0.4s ease;
@@ -324,53 +334,34 @@ main {
 }
 
 .card-image {
-  height: 180px;
-  background-color: var(--card-image-bg);
+  width: 180px;
+  background-image: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--primary-dark);
+  color: #fff;
   font-size: 2.5rem;
   overflow: hidden;
-  border-bottom: 1px solid var(--card-border);
-  position: relative;
 }
 .card-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.4s ease;
+  display: none;
 }
 .fav-btn {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: rgba(0, 0, 0, 0.4);
-  color: #fff;
-  border: none;
-  border-radius: 50%;
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid var(--primary);
+  border-radius: 8px;
+  padding: 8px 16px;
   cursor: pointer;
-  transition: background-color 0.3s;
+  transition: background-color 0.3s, color 0.3s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
-.fav-btn i {
-  pointer-events: none;
-}
-.fav-btn:hover {
-  background: var(--primary);
-}
+.fav-btn:hover,
 .fav-btn.active {
   background: var(--primary);
-}
-.fav-btn.active i {
   color: #fff;
-}
-.card:hover .card-image img {
-  transform: scale(1.05);
 }
 
 .card-content {
@@ -379,7 +370,7 @@ main {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  text-align: right;
+  text-align: left;
 }
 .card-content h3 {
   font-size: 1.3rem;
@@ -560,7 +551,7 @@ main {
   main {
     padding: 20px 30px 30px 30px;
   }
-  .card-grid {
+  .card-list {
     gap: 30px;
   }
 }
@@ -641,8 +632,7 @@ main {
     font-size: 1rem;
   }
 
-  .card-grid {
-    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  .card-list {
     gap: 20px;
   }
   .card {
@@ -667,8 +657,7 @@ main {
 }
 
 @media (max-width: 480px) {
-  .card-grid {
-    grid-template-columns: 1fr;
+  .card-list {
     gap: 25px;
   }
   .card {
@@ -747,6 +736,15 @@ main {
   border: 1px solid var(--card-border);
   border-radius: 6px;
   font-size: 0.9rem;
+}
+.modal textarea {
+  width: 100%;
+  padding: 8px 12px;
+  margin-top: 4px;
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  resize: vertical;
 }
 .modal-actions {
   margin-top: 15px;

--- a/index.html
+++ b/index.html
@@ -27,9 +27,12 @@
             <li><a href="About.html">About</a></li>
             <li><a href="Contact.html">Contact</a></li>
             <li><a href="Login.html">Login</a></li>
-            <li>
-              <button id="toggle-theme" class="btn outline">Toggle Theme</button>
-            </li>
+              <li>
+                <button id="toggle-theme" class="btn outline">Theme</button>
+              </li>
+              <li>
+                <button id="addCardBtn" class="btn">Add Card</button>
+              </li>
           </ul>
         </nav>
       </div>
@@ -39,20 +42,9 @@
   <!-- ========== WRAPPER: ALL SCROLLABLE CONTENT ========== -->
   <div id="smooth-wrapper">
     <div class="content-wrapper">
-      <aside class="category-sidebar">
-        <input
-          type="text"
-          id="searchInput"
-          class="search-input"
-          placeholder="Search..."
-        />
-        <div id="categoryTabs"></div>
-        <button id="addCardBtn" class="btn">Add Card</button>
-      </aside>
-
       <main>
         <section class="grid-section">
-          <div class="card-grid" id="cardContainer"></div>
+          <div class="card-list" id="cardContainer"></div>
         </section>
       </main>
     </div>
@@ -66,12 +58,16 @@
         <h2>Add Card</h2>
         <form id="addCardForm">
           <label>
-            Title
+            Website Name
             <input type="text" name="title" required />
           </label>
           <label>
-            URL
+            Website Link
             <input type="url" name="url" required />
+          </label>
+          <label>
+            Short Description
+            <textarea name="description" rows="3"></textarea>
           </label>
           <div class="modal-actions">
             <button type="button" id="cancelAddCard" class="btn outline">


### PR DESCRIPTION
## Summary
- replace sidebar with a cleaner card list
- move add card button to header
- redesign theme button and rename to *Theme*
- switch to Quicksand font across the site
- rework card layout to horizontal style
- add gradient colors and two new themes
- remove live thumbnails and show gradient icons
- enhance add-card modal and preload default cards

## Testing
- `npx stylelint Styles/index_style.css` *(fails: stylelint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840bbf9d98c832699db27ade24f1f48

## Summary by Sourcery

Overhaul the UI with a new Quicksand font, gradient-based themes, and a streamlined card interface; simplify card rendering logic, preload default cards, and relocate key controls to the header.

New Features:
- Add two new themes (teal and orange) with gradient variables across all theme files
- Preload a set of default cards when no saved data exists
- Introduce a short description field in the add-card modal for richer card metadata
- Add an "Add Card" button to the header for quick access

Enhancements:
- Switch site font from Inter to Quicksand with multiple weights
- Convert card container from a grid to a vertical list with horizontal card layout and gradient icon backgrounds
- Redesign the theme toggle button using gradient backgrounds and updated hover/active effects
- Simplify card actions to a single open link and favorite toggle
- Remove lazy-loaded thumbnails and live snapshots in favor of static gradient icons
- Rename and refactor CSS classes (card-grid → card-list) and remove the sidebar layout