### PR TITLE
Implement add card modal and options

### DIFF
--- a/Scripts/index_script.js
+++ b/Scripts/index_script.js
@@ -45,7 +45,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  /* Temporarily disable Add Card modal functions
   function openAddCardModal() {
     if (addCardOverlay) addCardOverlay.classList.add("show");
   }
@@ -53,7 +52,6 @@ document.addEventListener("DOMContentLoaded", () => {
   function closeAddCardModal() {
     if (addCardOverlay) addCardOverlay.classList.remove("show");
   }
-  */
 
   // =================== THEME SWITCHER ===================
   const themes = [
@@ -162,6 +160,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Basic structure with placeholders for image/icon
     cardElement.innerHTML = `
+      <div class="card-options">
+        <button class="options-btn"><i class="fas fa-ellipsis-v"></i></button>
+        <ul class="options-menu">
+          <li class="remove-option">Remove</li>
+        </ul>
+      </div>
       <div class="card-image">
         <i class="${cardInfo.icon || "fas fa-globe"}"></i>
       </div>
@@ -186,15 +190,14 @@ document.addEventListener("DOMContentLoaded", () => {
           }" class="btn" target="_blank" rel="noopener noreferrer">
             <i class="fas fa-external-link-alt"></i> Open
           </a>
-          <button class="remove-btn">
-            <i class="fas fa-times"></i> Remove
-          </button>
         </div>
       </div>
     `;
 
     const favButton = cardElement.querySelector(".fav-btn");
-    const removeButton = cardElement.querySelector(".remove-btn");
+    const options = cardElement.querySelector(".card-options");
+    const optionsBtn = cardElement.querySelector(".options-btn");
+    const removeOption = cardElement.querySelector(".remove-option");
 
     favButton.addEventListener("click", () => {
       if (favorites.has(cardInfo.url)) {
@@ -212,7 +215,19 @@ document.addEventListener("DOMContentLoaded", () => {
       );
     });
 
-    removeButton.addEventListener("click", () => {
+    optionsBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      options.classList.toggle("show");
+    });
+
+    document.addEventListener("click", (e) => {
+      if (!options.contains(e.target)) {
+        options.classList.remove("show");
+      }
+    });
+
+    removeOption.addEventListener("click", () => {
+      options.classList.remove("show");
       allCardsData = allCardsData.filter((c) => c.url !== cardInfo.url);
       localStorage.setItem("cardsDataALDMC", JSON.stringify(allCardsData));
       renderCards(currentCategory, searchInput ? searchInput.value : "");
@@ -257,7 +272,12 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       if (filteredData.length === 0) {
-        cardContainer.innerHTML = '<p class="no-results">Nothing to Show</p>';
+        const btn = document.createElement("button");
+        btn.id = "emptyAddCardBtn";
+        btn.className = "add-card-empty";
+        btn.textContent = "Add Card";
+        cardContainer.appendChild(btn);
+        btn.addEventListener("click", openAddCardModal);
       } else {
         filteredData.forEach((cardInfo) => {
           fragment.appendChild(createCardElement(cardInfo, searchQuery));
@@ -295,9 +315,13 @@ document.addEventListener("DOMContentLoaded", () => {
     searchInput.addEventListener("input", handleSearch);
   }
 
-  /*
   if (addCardBtn && addCardOverlay && addCardForm) {
-    addCardBtn.addEventListener("click", openAddCardModal);
+    const attachModalListeners = (btn) => {
+      if (btn) btn.addEventListener("click", openAddCardModal);
+    };
+
+    attachModalListeners(addCardBtn);
+
     cancelAddCard.addEventListener("click", closeAddCardModal);
     addCardOverlay.addEventListener("click", (e) => {
       if (e.target === addCardOverlay) {
@@ -309,13 +333,17 @@ document.addEventListener("DOMContentLoaded", () => {
       e.preventDefault();
       const formData = new FormData(addCardForm);
       const title = formData.get("title").trim();
-      const url = formData.get("url").trim();
+      let url = formData.get("url").trim();
       const description = formData.get("description").trim();
+      const category = formData.get("category").trim();
       if (!title || !isValidUrl(url)) {
         alert("Please enter a valid title and URL");
         return;
       }
-      const newCard = { title, url, description };
+      if (!url.startsWith("http")) {
+        url = `https://${url}`;
+      }
+      const newCard = { title, url, description, category };
       try {
         const stored = JSON.parse(localStorage.getItem("cardsDataALDMC")) || [];
         stored.push(newCard);
@@ -329,7 +357,6 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   }
-  */
 
   // =================== INITIAL DATA FETCH & RENDER ===================
   const defaultCards = [

--- a/Styles/index_style.css
+++ b/Styles/index_style.css
@@ -348,6 +348,16 @@ main {
   padding: 40px;
 }
 
+.add-card-empty {
+  background: rgba(var(--primary-rgb, 255, 111, 60), 0.05);
+  border: 2px dashed var(--primary);
+  color: var(--text);
+  padding: 40px 20px;
+  border-radius: 12px;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
 /* =================== CARD =================== */
 .card {
   background-color: var(--card-bg, #fff);
@@ -363,6 +373,7 @@ main {
     box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.4s ease,
     border-color 0.4s ease;
   cursor: default;
+  position: relative;
 }
 .card:hover {
   transform: translateY(-4px);
@@ -387,6 +398,51 @@ main {
 
 .card-image img {
   display: none;
+}
+
+/* Options menu inside card */
+.card-options {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.options-btn {
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+}
+
+.options-menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: 4px;
+  background: var(--dropdown-bg);
+  color: var(--dropdown-text);
+  border: 1px solid var(--category-border);
+  border-radius: 8px;
+  list-style: none;
+  padding: 6px 0;
+  min-width: 120px;
+  z-index: 10;
+}
+
+.card-options.show .options-menu {
+  display: block;
+}
+
+.options-menu li {
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.options-menu li:hover {
+  background: rgba(var(--primary-rgb, 255, 111, 60), 0.15);
 }
 .fav-btn {
   background: transparent;
@@ -744,7 +800,7 @@ main {
   border-radius: 12px;
   padding: 20px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  width: 320px;
+  width: 450px;
 }
 .modal h2 {
   margin-bottom: 15px;

--- a/index.html
+++ b/index.html
@@ -73,6 +73,10 @@
             Short Description
             <textarea name="description" rows="3"></textarea>
           </label>
+          <label>
+            Category
+            <input type="text" name="category" />
+          </label>
           <div class="modal-actions">
             <button type="button" id="cancelAddCard" class="btn outline">
               Cancel


### PR DESCRIPTION
## Summary
- enlarge the add card modal and allow entering a category
- show a bordered `Add Card` button when there are no cards
- implement per-card dropdown menu with remove action
- update scripts to support adding and removing cards

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841c73444888326895e208282b90529